### PR TITLE
Fixed misnamed tools

### DIFF
--- a/infogathering/index.md
+++ b/infogathering/index.md
@@ -154,9 +154,13 @@ Telephony Analysis
 Traffic Analysis
 ------------
 
- * [first]()
- * [second]()
- * [third]()
+ * [cdpsnarf](../tools/cdpsnarf.md)
+ * [intrace](../tools/intrace.md)
+ * [irpas-ass](../tools/irpass-ass.md)
+ * [irpas-cdp](../tools/irpass-cdp.md)
+ * [p0f](../tools/p0f.md)
+ * [tcpflow](../tools/tcpflow.md)
+ * [wireshark](../tools/wireshark.md)
 
 VoIP Analysis
 ------------

--- a/infogathering/index.md
+++ b/infogathering/index.md
@@ -111,7 +111,7 @@ SMB Analysis
  * [acccheck](../tools/acccheck.md)
  * [nbtscan](../tools/nbtscan.md)
  * [nmap](../tools/nmap.md)
- * [zenmap](../tools.zenmap.md)
+ * [zenmap](../tools/zenmap.md)
 
 SMTP Analysis
 ------------

--- a/tools/acccheck.md
+++ b/tools/acccheck.md
@@ -2,6 +2,7 @@
 
 Notes
 -------
+The tool is designed as a password dictionary attack tool that targets windows authentication via the SMB protocol. It is really a wrapper script around the ‘smbclient’ binary, and as a result is dependent on it for its execution.
 
 Help Text
 -------
@@ -40,7 +41,26 @@ Attempt a single password against a single user.
 
 Example Usage
 -------
+The simplest way to run the tool is as follows:
+
+./acccheck.pl -t 10.10.10.1
+
+This mode of execution attempts to connect to the target ADMIN$ share with the username ‘Administrator’ and a [BLANK] for the password.
+
+./acccheck.pl -t 10.10.10.1 -u test -p test
+
+This mode of execution attempts to connect to the target IPC$ share with the username ‘test’ and a password ‘test’.
+
+Each -t, -u and -p flags can be substituted by -T, -U and -P, where each represents an input file rather than a single input from standard in.
+
+E.g.
+./acccheck.pl -T iplist -U userfile -P passwordfile
+
+Only use -v mode on very small dictionaries, otherwise, this has the affect of slowing the scan down to the rate the system writes to standard out.
+
+Any username/password combinations found are written to a file called ‘cracked’ in the working directory.
 
 Links
 -------
+Notes and example usage from: https://labs.portcullis.co.uk/tools/acccheck/
 

--- a/tools/acccheck.md
+++ b/tools/acccheck.md
@@ -1,0 +1,46 @@
+# acccheck
+
+Notes
+-------
+
+Help Text
+-------
+```
+acccheck.pl v0.2.1 - By Faiz
+
+Description:
+Attempts to connect to the IPC$ and ADMIN$ shares depending on which flags have been
+chosen, and tries a combination of usernames and passwords in the hope to identify
+the password to a given account via a dictionary password guessing attack.
+
+Usage = ./acccheck.pl [optional]
+
+ -t [single host IP address]
+ OR 
+ -T [file containing target ip address(es)]
+
+Optional:
+ -p [single password]
+ -P [file containing passwords]
+ -u [single user]
+ -U [file containing usernames]
+ -v [verbose mode]
+
+Examples
+Attempt the 'Administrator' account with a [BLANK] password.
+	acccheck.pl -t 10.10.10.1
+Attempt all passwords in 'password.txt' against the 'Administrator' account.
+	acccheck.pl -t 10.10.10.1 -P password.txt
+Attempt all password in 'password.txt' against all users in 'users.txt'.
+	acccehck.pl -t 10.10.10.1 -U users.txt -P password.txt
+Attempt a single password against a single user.
+	acccheck.pl -t 10.10.10.1 -u administrator -p password
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/ace.md
+++ b/tools/ace.md
@@ -1,7 +1,10 @@
-# ace Automated Corporate (Data) Enumerator
+# ace - Automated Corporate (Data) Enumerator
 
 Notes
 -------
+ACE (Automated Corporate Enumerator) is a simple yet powerful VoIP Corporate Directory enumeration tool that mimics the behavior of an IP Phone in order to download the name and extension entries that a given phone can display on its screen interface. In the same way that the "corporate directory" feature of VoIP hardphones enables users to easily dial by name via their VoIP handsets, ACE was developed as a research idea born from "VoIP Hopper" to automate VoIP attacks that can be targeted against names in an enterprise Directory. The concept is that in the future, attacks will be carried out against users based on their name, rather than targeting VoIP traffic against random RTP audio streams or IP addresses. ACE works by using DHCP, TFTP, and HTTP in order to download the VoIP corporate directory. It then outputs the directory to a text file, which can be used as input to other VoIP assessment tools. ACE is a standalone utility, but its functions are integrated into UCSniff.
+
+From: http://ucsniff.sourceforge.net/ace.html
 
 Help Text
 -------
@@ -49,4 +52,4 @@ Example Usage
 
 Links
 -------
-
+http://ucsniff.sourceforge.net/ace.html

--- a/tools/cge.pl.md
+++ b/tools/cge.pl.md
@@ -1,0 +1,35 @@
+# cge.pl - Cisco-Global-exploiter
+
+Notes
+-------
+
+Help Text
+-------
+```
+Usage :
+perl cge.pl <target> <vulnerability number>
+
+Vulnerabilities list :
+[1] - Cisco 677/678 Telnet Buffer Overflow Vulnerability
+[2] - Cisco IOS Router Denial of Service Vulnerability
+[3] - Cisco IOS HTTP Auth Vulnerability
+[4] - Cisco IOS HTTP Configuration Arbitrary Administrative Access Vulnerability
+[5] - Cisco Catalyst SSH Protocol Mismatch Denial of Service Vulnerability
+[6] - Cisco 675 Web Administration Denial of Service Vulnerability
+[7] - Cisco Catalyst 3500 XL Remote Arbitrary Command Vulnerability
+[8] - Cisco IOS Software HTTP Request Denial of Service Vulnerability
+[9] - Cisco 514 UDP Flood Denial of Service Vulnerability
+[10] - CiscoSecure ACS for Windows NT Server Denial of Service Vulnerability
+[11] - Cisco Catalyst Memory Leak Vulnerability
+[12] - Cisco CatOS CiscoView HTTP Server Buffer Overflow Vulnerability
+[13] - 0 Encoding IDS Bypass Vulnerability (UTF)
+[14] - Cisco IOS HTTP Denial of Service Vulnerability
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/dnmap-client.md
+++ b/tools/dnmap-client.md
@@ -1,4 +1,4 @@
-# dnmap_client
+# dnmap-client
 
 Notes
 -------

--- a/tools/dnmap-server.md
+++ b/tools/dnmap-server.md
@@ -1,4 +1,4 @@
-# dnmap_server
+# dnmap-server
 
 Notes
 -------

--- a/tools/implementation6.md
+++ b/tools/implementation6.md
@@ -1,0 +1,25 @@
+# implementation6
+
+Notes
+-------
+
+Help Text
+-------
+```
+implementation6 v2.1 (c) 2012 by van Hauser / THC <vh@thc.org> www.thc.org
+
+Syntax: implementation6 [-p] [-s sourceip6] interface destination [test-case-number]
+
+Options:
+  -s sourceip6  use the specified source IPv6 address
+  -p            do not perform an alive check at the beginning and end
+Performs some ipv6 implementation checks, can be used to test some
+firewall features too. Takes approx. 2 minutes to complete.
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/implementation6d.md
+++ b/tools/implementation6d.md
@@ -1,0 +1,23 @@
+# implementation6d
+
+Notes
+-------
+
+Help Text
+-------
+```
+implementation6d v2.1 (c) 2012 by van Hauser / THC <vh@thc.org> www.thc.org
+
+Syntax: implementation6d interface
+
+Identifies test packets by the implementation6 tool, useful to check what
+packets passed a firewall
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/intrace.md
+++ b/tools/intrace.md
@@ -1,0 +1,18 @@
+# intrace
+
+Notes
+-------
+
+Help Text
+-------
+```
+InTrace, version 1.5 (C)2007-2011 Robert Swiecki <robert@swiecki.net>
+2014/03/30 15:34:27.143598 <INFO> Usage: intrace <-h hostname> [-p <port>] [-d <debuglevel>] [-s <payloadsize>] [-6]
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/irpass-ass.md
+++ b/tools/irpass-ass.md
@@ -1,0 +1,23 @@
+# ass - irpass-ass 
+
+Notes
+-------
+
+Help Text
+-------
+```
+ass: invalid option -- 'h'
+ass [-v[v[v]]] -i <interface> [-ApcMs] [-P IER12]
+	[-a <autonomous system start> -b <autonomous system stop>]
+	[-S <spoofed source IP>] [-D <destination ip>]
+	[-T <packets per delay>]
+	[-r <filename>]
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/irpass-cdp.md
+++ b/tools/irpass-cdp.md
@@ -1,0 +1,34 @@
+# cdp - irpass-cdp
+
+Notes
+-------
+
+Help Text
+-------
+```
+cdp [-v] -i <interface> -m {0,1} ...
+
+Flood mode (-m 0):
+-n <number>	number of packets
+-l <number>	length of the device id
+-c <char>	character to fill in device id
+-r		randomize device id string
+
+Spoof mode (-m 1):
+-D <string>	Device id
+-P <string>	Port id
+-L <string>	Platform
+-S <string>	Software
+-F <string>	IP address
+-C <capabilities>
+	these are:
+	R - Router, T - Trans Bridge, B - Source Route Bridge
+	S - Switch, H - Host, I - IGMP, r - Repeater
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/nbtscan.md
+++ b/tools/nbtscan.md
@@ -1,0 +1,62 @@
+# nbtscan
+
+Notes
+-------
+
+Help Text
+-------
+```
+"Human-readable service names" (-h) option cannot be used without verbose (-v) option.
+Usage:
+nbtscan [-v] [-d] [-e] [-l] [-t timeout] [-b bandwidth] [-r] [-q] [-s separator] [-m retransmits] (-f filename)|(<scan_range>) 
+	-v		verbose output. Print all names received
+			from each host
+	-d		dump packets. Print whole packet contents.
+	-e		Format output in /etc/hosts format.
+	-l		Format output in lmhosts format.
+			Cannot be used with -v, -s or -h options.
+	-t timeout	wait timeout milliseconds for response.
+			Default 1000.
+	-b bandwidth	Output throttling. Slow down output
+			so that it uses no more that bandwidth bps.
+			Useful on slow links, so that ougoing queries
+			don't get dropped.
+	-r		use local port 137 for scans. Win95 boxes
+			respond to this only.
+			You need to be root to use this option on Unix.
+	-q		Suppress banners and error messages,
+	-s separator	Script-friendly output. Don't print
+			column and record headers, separate fields with separator.
+	-h		Print human-readable names for services.
+			Can only be used with -v option.
+	-m retransmits	Number of retransmits. Default 0.
+	-f filename	Take IP addresses to scan from file filename.
+			-f - makes nbtscan take IP addresses from stdin.
+	<scan_range>	what to scan. Can either be single IP
+			like 192.168.1.1 or
+			range of addresses in one of two forms: 
+			xxx.xxx.xxx.xxx/xx or xxx.xxx.xxx.xxx-xxx.
+Examples:
+	nbtscan -r 192.168.1.0/24
+		Scans the whole C-class network.
+	nbtscan 192.168.1.25-137
+		Scans a range from 192.168.1.25 to 192.168.1.137
+	nbtscan -v -s : 192.168.1.0/24
+		Scans C-class network. Prints results in script-friendly
+		format using colon as field separator.
+		Produces output like that:
+		192.168.0.1:NT_SERVER:00U
+		192.168.0.1:MY_DOMAIN:00G
+		192.168.0.1:ADMINISTRATOR:03U
+		192.168.0.2:OTHER_BOX:00U
+		...
+	nbtscan -f iplist
+		Scans IP addresses specified in file iplist.
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/ocs.md
+++ b/tools/ocs.md
@@ -1,0 +1,29 @@
+# osc - cisco-ocs
+
+Notes
+-------
+
+Help Text
+-------
+```
+********************************* OCS v 0.1 **********************************
+****                                                                      ****
+****                           coded by OverIP                            ****
+****                                                                      ****
+****                          under GPL License                           ****
+****                                                                      ****
+****             usage: ./ocs xxx.xxx.xxx.xxx yyy.yyy.yyy.yyy             ****
+****                                                                      ****
+****                   xxx.xxx.xxx.xxx = range start IP                   ****
+****                    yyy.yyy.yyy.yyy = range end IP                    ****
+****                                                                      ****
+******************************************************************************
+uso: ocs IP IP
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/p0f.md
+++ b/tools/p0f.md
@@ -1,0 +1,70 @@
+# p0f
+
+Notes
+-------
+"P0f is a tool that utilizes an array of sophisticated, purely passive traffic fingerprinting mechanisms to identify the players behind any incidental TCP/IP communications (often as little as a single normal SYN) without interfering in any way. Version 3 is a complete rewrite of the original codebase, incorporating a significant number of improvements to network-level fingerprinting, and introducing the ability to reason about application-level payloads (e.g., HTTP).
+Some of p0f's capabilities include:
+
+ * Highly scalable and extremely fast identification of the operating system and software on both endpoints of a vanilla TCP connection - especially in settings where NMap probes are blocked, too slow, unreliable, or would simply set off alarms.
+ * Measurement of system uptime and network hookup, distance (including topology behind NAT or packet filters), user language preferences, and so on.
+ * Automated detection of connection sharing / NAT, load balancing, and application-level proxying setups.
+ * Detection of clients and servers that forge declarative statements such as X-Mailer or User-Agent.
+
+"The tool can be operated in the foreground or as a daemon, and offers a simple real-time API for third-party components that wish to obtain additional information about the actors they are talking to.
+Common uses for p0f include reconnaissance during penetration tests; routine network monitoring; detection of unauthorized network interconnects in corporate environments; providing signals for abuse-prevention tools; and miscellanous forensics."
+
+From: http://lcamtuf.coredump.cx/p0f3/
+
+
+Help Text
+-------
+```
+p0f: invalid option -- 'h'
+
+Usage: p0f [ -f file ] [ -i device ] [ -s file ] [ -o file ]
+       [ -w file ] [ -Q sock [ -0 ] ] [ -u user ] [ -FXVNDUKASCMROqtpvdlrx ]
+       [ -c size ] [ -T nn ] [ -e nn ] [ 'filter rule' ]
+  -f file   - read fingerprints from file
+  -i device - listen on this device
+  -s file   - read packets from tcpdump snapshot
+  -o file   - write to this logfile (implies -t)
+  -w file   - save packets to tcpdump snapshot
+  -u user   - chroot and setuid to this user
+  -Q sock   - listen on local socket for queries
+  -0        - make src port 0 a wildcard (in query mode)
+  -e ms     - pcap capture timeout in milliseconds (default: 1)
+  -c size   - cache size for -Q and -M options
+  -M        - run masquerade detection
+  -T nn     - set masquerade detection threshold (1-200)
+  -V        - verbose masquerade flags reporting
+  -F        - use fuzzy matching (do not combine with -R)
+  -N        - do not report distances and link media
+  -D        - do not report OS details (just genre)
+  -U        - do not display unknown signatures
+  -K        - do not display known signatures (for tests)
+  -S        - report signatures even for known systems
+  -A        - go into SYN+ACK mode (semi-supported)
+  -R        - go into RST/RST+ACK mode (semi-supported)
+  -O        - go into stray ACK mode (barely supported)
+  -r        - resolve host names (not recommended)
+  -q        - be quiet - no banner
+  -v        - enable support for 802.1Q VLAN frames
+  -p        - switch card to promiscuous mode
+  -d        - daemon mode (fork into background)
+  -l        - use single-line output (easier to grep)
+  -x        - include full packet dump (for debugging)
+  -X        - display payload string (useful in RST mode)
+  -C        - run signature collision check
+  -t        - add timestamps to every entry
+
+  'Filter rule' is an optional pcap-style BPF expression (man tcpdump).
+
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/tcpflow.md
+++ b/tools/tcpflow.md
@@ -1,0 +1,37 @@
+# tcpflow
+
+Notes
+-------
+
+Help Text
+-------
+```
+tcpflow version 0.21 by Jeremy Elson <jelson@circlemud.org>
+
+usage: tcpflow [-chpsv] [-b max_bytes] [-d debug_level] [-f max_fds]
+          [-i iface] [-r file] [expression]
+
+        -b: max number of bytes per flow to save
+        -c: console print only (don't create files)
+        -C: console print only, but without the display of source/dest header
+        -d: debug level; default is 1
+        -e: output each flow in alternating colors
+        -f: maximum number of file descriptors to use
+        -h: print this help message
+        -i: network interface on which to listen
+            (type "ifconfig -a" for a list of interfaces)
+        -p: don't use promiscuous mode
+        -r: read packets from tcpdump output file
+        -s: strip non-printable characters (change to '.')
+        -v: verbose operation equivalent to -d 10
+expression: tcpdump-like filtering expression
+
+See the man page for additional information.
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/tools/wireshark.md
+++ b/tools/wireshark.md
@@ -1,0 +1,82 @@
+# wireshark
+
+Notes
+-------
+
+Help Text
+-------
+```
+Wireshark 1.8.5
+Interactively dump and analyze network traffic.
+See http://www.wireshark.org for more information.
+
+Copyright 1998-2013 Gerald Combs <gerald@wireshark.org> and contributors.
+This is free software; see the source for copying conditions. There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Usage: wireshark [options] ... [ <infile> ]
+
+Capture interface:
+  -i <interface>           name or idx of interface (def: first non-loopback)
+  -f <capture filter>      packet filter in libpcap filter syntax
+  -s <snaplen>             packet snapshot length (def: 65535)
+  -p                       don't capture in promiscuous mode
+  -k                       start capturing immediately (def: do nothing)
+  -S                       update packet display when new packets are captured
+  -l                       turn on automatic scrolling while -S is in use
+  -I                       capture in monitor mode, if available
+  -B <buffer size>         size of kernel buffer (def: 1MB)
+  -y <link type>           link layer type (def: first appropriate)
+  -D                       print list of interfaces and exit
+  -L                       print list of link-layer types of iface and exit
+
+Capture stop conditions:
+  -c <packet count>        stop after n packets (def: infinite)
+  -a <autostop cond.> ...  duration:NUM - stop after NUM seconds
+                           filesize:NUM - stop this file after NUM KB
+                              files:NUM - stop after NUM files
+Capture output:
+  -b <ringbuffer opt.> ... duration:NUM - switch to next file after NUM secs
+                           filesize:NUM - switch to next file after NUM KB
+                              files:NUM - ringbuffer: replace after NUM files
+Input file:
+  -r <infile>              set the filename to read from (no pipes or stdin!)
+
+Processing:
+  -R <read filter>         packet filter in Wireshark display filter syntax
+  -n                       disable all name resolutions (def: all enabled)
+  -N <name resolve flags>  enable specific name resolution(s): "mntC"
+
+User interface:
+  -C <config profile>      start with specified configuration profile
+  -d <display filter>      start with the given display filter
+  -g <packet number>       go to specified packet number after "-r"
+  -J <jump filter>         jump to the first packet matching the (display)
+                           filter
+  -j                       search backwards for a matching packet after "-J"
+  -m <font>                set the font name used for most text
+  -t ad|a|r|d|dd|e         output format of time stamps (def: r: rel. to first)
+  -u s|hms                 output format of seconds (def: s: seconds)
+  -X <key>:<value>         eXtension options, see man page for details
+  -z <statistics>          show various statistics, see man page for details
+
+Output:
+  -w <outfile|->           set the output filename (or '-' for stdout)
+
+Miscellaneous:
+  -h                       display this help and exit
+  -v                       display version info and exit
+  -P <key>:<path>          persconf:path - personal configuration files
+                           persdata:path - personal data files
+  -o <name>:<value> ...    override preference or recent setting
+  -K <keytab>              keytab file to use for kerberos decryption
+  --display=DISPLAY        X display to use
+
+```
+
+Example Usage
+-------
+
+Links
+-------
+

--- a/vulnanalysis/index.md
+++ b/vulnanalysis/index.md
@@ -1,107 +1,70 @@
+# Vulnerability Analysis
+
 Cisco Tools
 -----------
 
-### cisco-auditing-tool
-
-### cisco-global-exploiter
-
-### cisco-ocs
-
-### cisco-torch
-
-### yersinia
+ * [cisco-auditing-tool](../tools/CAT.md)
+ * [cisco-global-exploiter] (../tools/cge.pl.md)
+ * [cisco-ocs]
+ * [cisco-torch](../tools/cisco-torch.md)
+ * [yersinia]
 
 Database Assessment
 -------------------
 
-### bbqsql
-
-### dbpwaudit
-
-### hexorbase
-
-### jsql
-
-### mdb-export
-
-### mdb-hexdump
-
-### mdb-parsecsv
-
-### mdb-sql
-
-### mdb-tables
-
-### oscanner
-
-### sidguesser
-
-### sqldict
-
-### sqlmap
-
-### sqlninja
-
-### sqlsus
-
-### tnscmd10g
+ * [bbqsql]
+ * [dbpwaudit]
+ * [hexorbase]
+ * [jsql]
+ * [mdb-export]
+ * [mdb-hexdump]
+ * [mdb-parsecsv]
+ * [mdb-sql]
+ * [mdb-tables]
+ * [oscanner]
+ * [sidguesser]
+ * [sqldict]
+ * [sqlmap]
+ * [sqlninja]
+ * [sqlsus]
+ * [tnscmd10g]
 
 Fuzzing Tools
 -------------
 
-### bed
-
-### fuzz_ip6
-
-### ohrwurm
-
-### powerfuzzer
-
-### sfuzz
-
-### siparmyknife
-
-### spike-generic_chunked
-
-### spike-generic_listen_tcp
-
-### spike-generic_send_tcp
-
-### spike-generic_send_udp
+ * [bed]
+ * [fuzz_ip6]
+ * [ohrwurm]
+ * [powerfuzzer]
+ * [sfuzz]
+ * [siparmyknife]
+ * [spike-generic_chunked]
+ * [spike-generic_listen_tcp]
+ * [spike-generic_send_tcp]
+ * [spike-generic_send_udp]
 
 Misc Scanners
 -------------
 
-### golismero
-
-### lynis
-
-### nikto
-
-### nmap
-
-### unix-privesc-check
-
-### zenmap
+ * [golismero]
+ * [lynis]
+ * [nikto]
+ * [nmap](../tools/nmap.md)
+ * [unix-privesc-check]
+ * [zenmap](../tools/zenmap.md)
 
 Open Source Assessment
 ----------------------
 
-### casefile
-
-### maltego
+ * [casefile]
+ * [maltego]
 
 OpenVAS
 -------
 
-### openvas check setup
-
-### openvas feedupdate
-
-### openvas-gsd
-
-### openvas initial setup
-
-### openvas start
-
-### openvas stop
+ * [openvas check setup]
+ * [openvas feedupdate]
+ * [openvas-gsd]
+ * [openvas initial setup]
+ * [openvas start]
+ * [openvas stop]


### PR DESCRIPTION
Fixed dnmap client and server. They were named dnmap_client and
dnmap_server; I changed the named to dnmap-client and dnmap-server,
fixing two dead links in route analysis.
